### PR TITLE
Add a note about the --disable-webusb-security flag.

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,7 +65,10 @@
   <td>Implemented behind the experimental flag <code>chrome://flags/#enable-web-bluetooth</code>.</td>
 </tr>
 <tr><td>USB</td>
-  <td>Implemented behind the experimental flag <code>chrome://flags/#enable-experimental-web-platform-features</code>.</td>
+  <td>
+    Implemented behind the experimental flag <code>chrome://flags/#enable-experimental-web-platform-features</code>.
+    Pass <code>--disable-webusb-security</code> on the command line to allow this site to request any device.
+  </td>
 </tr>
 <tr><td>Encrypted Media (EME)</td>
   <td>May succeed without permission depending on the implementation.<br>


### PR DESCRIPTION
Chrome will allow a site to request any device through WebUSB if the
--disable-webusb-security flag is passed on the command line.
