### PR TITLE
Add audioCapabilities to Encrypted Media test

### DIFF
--- a/index.js
+++ b/index.js
@@ -164,20 +164,33 @@ window.addEventListener("load", function() {
         "com.example.somesystem"  // Ensure no real system is the last tried.
       ];
       var tryKeySystem = function(keySystem) {
+        // http://w3c.github.io/encrypted-media/#idl-def-mediakeysystemconfiguration
+        // One of videoCapabilities or audioCapabilities must be present. Pick
+        // a set that all browsers should support at least one of.
+        var capabilities = [
+          { contentType: 'audio/mp4; codecs="mp4a.40.2"' },
+          { contentType: 'audio/webm; codecs="opus"' },
+        ];
         navigator.requestMediaKeySystemAccess(
           keySystem,
           [
             { distinctiveIdentifier: "required",
               persistentState: "required",
+              audioCapabilities: capabilities,
               label: "'distinctiveIdentifier' and 'persistentState' required"
             },
             { distinctiveIdentifier: "required",
+              audioCapabilities: capabilities,
               label: "'distinctiveIdentifier' required"
             },
             { persistentState: "required",
+              audioCapabilities: capabilities,
               label: "'persistentState' required"
             },
-            { label: "empty" }
+            { audioCapabilities: capabilities,
+              label: "empty"
+            },
+            { label: "no capabilities" }
           ]
         ).then(
           function (mediaKeySystemAccess) {


### PR DESCRIPTION
The EME specification requires that at least one of audioCapabilities or
videoCapabilities be specified in the configuration passed to
navigator.requestMediaKeySystemAccess(). Adding a set of capabilities for
audio that some subset should be supported on all platforms.