### PR TITLE
Use 'acceptAllDevices' for Bluetooth.

### DIFF
--- a/index.js
+++ b/index.js
@@ -135,7 +135,9 @@ window.addEventListener("load", function() {
     },
     "bluetooth": function() {
       navigator.bluetooth.requestDevice({
-        filters: [{services: ['battery_service']}]
+        // filters: [...] <- Prefer filters to save energy & show relevant devices.
+        // acceptAllDevices here ensures dialog can populate, we don't care with what.
+        acceptAllDevices:true
       }).then(
         displayOutcome("bluetooth", "success"),
         displayOutcome("bluetooth", "error")


### PR DESCRIPTION
On this site we do not care what devices are found. Using the acceptAllDevices
option increases the chance that the Bluetooth chooser finds any device at all.